### PR TITLE
update workflow to add configuration files to secrets

### DIFF
--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Add Config data from Secret
         id: set-config-data
-        if: [[ -n ${{ env.CONFIG_JSON }} ]]
+        # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
           sed -ibak -e "
           s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -90,7 +90,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -e -ibak "s|//SECRET_DATA|$CONFIG_DATA|g" git-info.js
+          sed -ibak -e "s|//SECRET_DATA|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON }}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -76,6 +76,7 @@ jobs:
           s/COMMITACTOR/$COMMIT_ACTOR/g;
           s/EVENTNAME/$EVENT_NAME/g;
           s/JOBID/$GITHUB_JOB/g;
+          s|//SECRET_DATA|$CONFIG_DATA|g;
           s|GITHUBREPOSITORY|$GITHUB_REPOSITORY|g" git-info.js
         env:
           COMMIT_SHA: ${{ github.sha }}
@@ -84,15 +85,16 @@ jobs:
           GITHUB_JOB: ${{ github.job }}
           GITHUB_REPOSITORY: ${{ github.repository }} 
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          CONFIG_DATA: ${{ secrets.CONFIG_JSON }}
           # 🐧
 
-      - name: Add Config data from Secret
-        id: set-config-data
-        # if: [[ -n ${{ env.CONFIG_JSON }} 
-        run: >
-          sed -ibak -e "s|//SECRET_DATA|$CONFIG_DATA|g" git-info.js
-        env:
-          CONFIG_DATA: ${{ secrets.CONFIG_JSON }}
+      # - name: Add Config data from Secret
+      #   id: set-config-data
+      #   # if: [[ -n ${{ env.CONFIG_JSON }} 
+      #   run: >
+      #     sed -ibak -e "s|//SECRET_DATA|$CONFIG_DATA|g" git-info.js
+      #   env:
+      #     CONFIG_DATA: ${{ secrets.CONFIG_JSON }}
 
       - name: Push script to scripts.google.com
         id: clasp-push

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,7 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -ibak -e "s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+          sed -ibak -e "s|\/\/SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,7 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -e "s|no:data|$CONFIG_DATA|g" git-info.js
+          sed -e "s|data|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -71,13 +71,13 @@ jobs:
       - name: update git-info.js
         id: modify-git-info
         run: >
-          sed -ibak -e "s/COMMITSHA/$COMMIT_SHA/g;
+          sed -ibak -e 's/COMMITSHA/$COMMIT_SHA/g;
           s/REFNAME/$GITHUB_REF_NAME/g;
           s/COMMITACTOR/$COMMIT_ACTOR/g;
           s/EVENTNAME/$EVENT_NAME/g;
           s/JOBID/$GITHUB_JOB/g;
           s|//SECRET_DATA|$CONFIG_DATA|g;
-          s|GITHUBREPOSITORY|$GITHUB_REPOSITORY|g" git-info.js
+          s|GITHUBREPOSITORY|$GITHUB_REPOSITORY|g' git-info.js
         env:
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,7 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -ibak -e "s| \/\/SECRET_DATA_GOES_HERE|$CONFIG_DATA|" git-info.js
+          sed -ibak -e "s|no:data|$CONFIG_DATA|" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,7 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -ibak -e "s|\/\/SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+          sed -ibak -e "s| \/\/SECRET_DATA_GOES_HERE|$CONFIG_DATA|" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -89,10 +89,10 @@ jobs:
 
       - name: Add Config data from Secret
         id: set-config-data
-        if: ${{ env.CONFIG_JSON }}
+        if: [[ -n ${{ env.CONFIG_JSON }} ]]
         run: >
           sed -ibak -e "
-          s|SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+          s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -77,6 +77,7 @@ jobs:
           s/EVENTNAME/$EVENT_NAME/g;
           s/JOBID/$GITHUB_JOB/g;
           s|GITHUBREPOSITORY|$GITHUB_REPOSITORY|g" git-info.js
+          
         env:
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
@@ -86,7 +87,14 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           # 🐧
 
-
+      - name: Add Config data from Secret
+        id: set-config-data
+        if: ${{ github.event_name	!= 'schedule' && env.CONFIG_JSON}}
+        run: >
+          sed -ibak -e "
+          s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+        env:
+          CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 
       - name: Push script to scripts.google.com
         id: clasp-push

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ env.CONFIG_JSON }}
         run: >
           sed -ibak -e "
-          s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+          s|SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -77,7 +77,6 @@ jobs:
           s/EVENTNAME/$EVENT_NAME/g;
           s/JOBID/$GITHUB_JOB/g;
           s|GITHUBREPOSITORY|$GITHUB_REPOSITORY|g" git-info.js
-          
         env:
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
@@ -91,9 +90,9 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -e "s|data|$CONFIG_DATA|g" git-info.js
+          sed -e -ibak "s|//SECRET_DATA|$CONFIG_DATA|g" git-info.js
         env:
-          CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
+          CONFIG_DATA: ${{ secrets.CONFIG_JSON }}
 
       - name: Push script to scripts.google.com
         id: clasp-push

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,8 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -ibak -e "
-          s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
+          sed -ibak -e "s|//SECRET_DATA_GOES_HERE|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -91,7 +91,7 @@ jobs:
         id: set-config-data
         # if: [[ -n ${{ env.CONFIG_JSON }} 
         run: >
-          sed -ibak -e "s|no:data|$CONFIG_DATA|" git-info.js
+          sed -e "s|no:data|$CONFIG_DATA|g" git-info.js
         env:
           CONFIG_DATA: ${{ secrets.CONFIG_JSON}}
 

--- a/demo-config.ts
+++ b/demo-config.ts
@@ -1,0 +1,124 @@
+let INTERNAL_CONFIG = {
+    // docIds
+
+    docIds_kicFormId: "KIC_FORM_ID", //The Document ID of the Key Indicators for Conversion Report Google Form (where missionaries submit their KICs every Sunday).    gcopy:'1CbCGdXXjPmQmpLKJAaER0cSYSGrb3ES3y2XGpr3czEw'    live:'1Zc-3omEIjAeQrmUxyG8YFk4PdnPf37XiFy3PRK2cP8g'
+
+    //   docIds_zoneTemplate: "1dKCcClYsNNneA4ty4-EtWg_hJl7BZ-v8Gl-5uPogiHs", //TODO No references - remove?
+    //   docIds_distTemplate: "1-y8VnTOqbYiW11nGVVVaC4iNjWE7jOcP2sMFpdzvqTM", //TODO No references - remove?
+    //   docIds_areaTemplate: "1TcIlXOnnUr_eXrDLN94tf-DB2A7eqeFBl0-QeNGKXAE", //TODO No references - remove?
+
+    reportCreator: {
+        docIDs: {
+
+            zoneTemplate: "ZONE_TEMPLATE_ID",
+            distTemplate: "DISTRICT_TEMPLATE_ID",
+            areaTemplate: "AREA_TEMPLATE_ID",
+        },
+        outputDataSheetName: "Data",
+        configPageSheetName: "config",
+        kicDataStoreSheetName: "Data",
+    },
+
+    // general
+
+    general_areaNameQuestionTitle: "Area Name",
+
+    general_deleteOldResponsesAgeLimit: 0, //The max age, in days, of a response before it is deleted (from the Form, not the Google Sheet). If set to 0, old responses will never be deleted.
+
+    // dataFlow
+
+    dataFlow_skipMarkingPulled: false, //Stops marking Form Responses as having been pulled into the data sheet
+
+    dataFlow_skipMarkingDuplicates: false, //TODO Re-implement?
+
+    dataFlow_freezeContactData: false,
+
+    dataFlow_formColumnsToExcludeFromDataSheet: [
+        "responsePulled",
+        "submissionEmail",
+    ],
+
+    dataFlow_forceAreaIdReloadOnUpdateDataSheet: false,
+
+    dataFlow_areaId_cacheExpirationLimit: 1800, //Maximum time in seconds before the cache gets reset
+
+    dataFlow_areaId_cacheKey: "butterflies and clouds", //ID to use when storing areaIDs in the cache
+
+    dataFlow_allSheetData_cacheEnabled: true, //Cache allSheetData, the object returned by constructSheetData()
+
+    dataFlow_allSheetData_cacheExpirationLimit: 1800, //Maximum time in seconds before the cache gets reset
+
+    dataFlow_allSheetData_cacheKey: "puppies and flowers", //ID to use when storing allSheetData in the cache
+
+    dataFlow_missionOrgData_cacheEnabled: false, //[unimplemented] Cache missionOrgData, the object returned by getMissionOrgData()
+
+    dataFlow_maxRowToMarkDuplicates: 500, //If set to -1, the full sheet will be checked (which takes a long time!). If set to 0, duplicates will not be marked.
+
+    commonLib: {
+        log_access_info: false, // if set to true, logger will tell you whether or not files are accessible
+        log_display_info: false, // if set to true, sendDataToDisplay & sendReportToDisplay will display extra debug information
+        log_display_info_extended: false, // if set to true, sendDataToDisplay & sendReportToDisplay will display even more debug information
+        log_time_taken: true, // if set to true, sendDataToDisplay & sendReportToDisplay will display how much time they took to run.  Pretty useful IMO
+    },
+
+    // fileSystem
+
+    fileSystem_reportLevel: { zone: "Zone", dist: "District", area: "Area" }, //Theoretically, since there's no difference between this anywhere you should be able to change this to be whatever gibberish you want as long as they're unique.  These strings also included in folder naming if INCLUDE_SCOPE_IN_FOLDER_NAME is set to true, so don't make them too pithy.
+
+    fileSystem_updateSheetProtectionsOnLoad: false, //WARNING: If set to true, loading the filesystem will take a VERY long time!
+
+    fileSystem_includeScopeInFolderName: false, // this cannot be set to true until driveHandler includes both the folder name string and the areaname separately.
+
+    fileSystem_freezeFilesys: false, //TODO Re-implement? Currently unimplemented
+
+    filesystem_log_existing_folders: false,
+    // logging
+
+    log_filesys: false, //TODO Update references
+    fileSystem_log_update: false,
+
+    fileSystem_log_fileShare: false,
+
+    LOG_OLD_sendReportToDisplayV3_: false, //TODO Update references
+    fileSystem_log_sendReportToDisplayV3_: false,
+
+    dataFlow_log_importContacts: false,
+    dataFlow_log_dataMerge: false,
+    dataFlow_log_responsePulled: false,
+    dataFlow_log_duplicates: false,
+
+    // triggers
+    triggers: {
+        installable: {
+            onOpen: true,
+            onEdit: false // not currently used
+        },
+        timeBased: {
+            updateForm: true,
+            updateDataSheet: true,
+            importContacts: true,
+            updateFileSystem: true,
+            updateAreaReports: true,
+            updateDistReports: true,
+            updateZoneReports: true,
+            shareFileSystem: true, // the default for this was false, now that accessControl has been finished, has been set to true.
+        },
+        menu: {
+            updateDataSheet: true,
+            updateFileSystem: false,
+            updateAreaReports: true,
+            updateDistReports: true,
+            updateZoneReports: true,
+            importContacts: true,
+            markDuplicates: true,
+            loadAreaIds: true,
+        }
+    },
+
+};
+
+const CONFIG = {
+    ...INTERNAL_CONFIG,
+    ...GITHUB_SECRET_DATA
+    // this way, all the data written to GITHUB_SECRET_DATA just winds up in config
+};

--- a/git-info.js
+++ b/git-info.js
@@ -12,7 +12,7 @@ const GITHUB_DATA = {
 
 
 const GITHUB_SECRET_DATA = {
-    //SECRET_DATA_GOES_HERE
+    no:data
 }
 
 

--- a/git-info.js
+++ b/git-info.js
@@ -14,5 +14,3 @@ const GITHUB_DATA = {
 const GITHUB_SECRET_DATA = {
     //SECRET_DATA
 }
-
-

--- a/git-info.js
+++ b/git-info.js
@@ -8,3 +8,11 @@ const GITHUB_DATA = {
     github_repository: "GITHUBREPOSITORY", // done
     github_branch_ref: "REFNAME" // done
 }
+
+
+
+const GITHUB_SECRET_DATA = {
+    //SECRET_DATA_GOES_HERE
+}
+
+

--- a/git-info.js
+++ b/git-info.js
@@ -12,7 +12,7 @@ const GITHUB_DATA = {
 
 
 const GITHUB_SECRET_DATA = {
-    no:data
+    //SECRET_DATA
 }
 
 

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,9 @@ The workflow can automatically deploy the script when the `main` branch is pushe
 
 (New!)  This allows you to stick extra config data that you want to supersede the stuff in the default configuration inside of an action secret.  It'd probably be a good idea to save the contents of this somewhere outside of your repository so that you can reference it later in case you need to make changes.  This will also make maintaining multiple deployments easier, as all deployment-specific configuration bits can be stuck in here.
 
+*NOTE: YOU HAVE TO USE DOUBLE-QUOTES, NOT SINGLE QUOTES! OTHERWISE THINGS* ***WILL*** *BREAK!*
+ - this is because of the way the action workflow is set up- it might be a little bit fragile 😅
+
 ##### Example snippet
 
 ```js
@@ -137,13 +140,13 @@ However, there are [conditions where the refresh token may also expire](https://
 
 ## GCP Service Accounts
 
-The whole system described here copying the credentials out of `.clasprc.json` and using a scheduled trigger to automatically update the tokens on a regular basis is a hack. 
+The whole system described here copying the credentials out of `.clasprc.json` and using a scheduled trigger to automatically update the tokens on a regular basis is a hack.
 
 The "correct" way to setup a server to server connection like is through a GCP service account. It is possible to login clasp using a key file for a service account. However, the [Apps Scripts API](https://developers.google.com/apps-script/api/concepts) does not work with service accounts.
 
 - [Execution API - cant use service account](https://issuetracker.google.com/issues/36763096)
 - [Can the Google Apps Script Execution API be called by a service account?](https://stackoverflow.com/questions/33306299/can-the-google-apps-script-execution-api-be-called-by-a-service-account)
-  
+
 ## Related Issues
 
 - [Provide instructions for deploying via CI #707](https://GitHub.com/google/clasp/issues/707)

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ The `clasp` command line tool uses a `.clasprc.json` file to store the current l
 #### `REPO_ACCESS_TOKEN`
 A GitHub personal access token must be provided to the workfow to allow it to update the `CLASPRC_JSON` secret configured about when tokens expire and refresh.
 
-1. Create a new [GitHubpersonal access token](https://github.com/settings/tokens/new) with `repo` scope.
+1. Create a new [GitHub personal access token](https://github.com/settings/tokens/new) with `repo` scope.
 2. Copy the token into a new secret named `REPO_ACCESS_TOKEN`
 
 #### `SCRIPT_ID` [OPTIONAL]

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ This repository is an example of how to setup an automatic [CI/CD](https://en.wi
 [Demo Google Sheet, Vanilla](https://docs.google.com/spreadsheets/d/1tli_An8Jg5-UQltOtRla7pz-mPRAYDfhExRkkVA2oJE/edit?usp=sharing)
 [Demo Google Sheet, Typescript](https://docs.google.com/spreadsheets/d/1jEbB5RxGvxuUd00X7UAuTqKZjBRqYsIt88dhF3tRHh8/edit?usp=sharing)
 
-## Using TypeScript:
+## Using TypeScript
 
 In your editor of choice, run [``npm install --save @types/google-apps-script``](https://www.npmjs.com/package/@types/google-apps-script)
 
@@ -102,16 +102,16 @@ The workflow can automatically deploy the script when the `main` branch is pushe
 ##### Example snippet
 
 ```js
-    {
-        docIds_kicFormId: "KIC_FORM_ID",
-        reportCreator: {
-            docIDs: {
-                zoneTemplate: "ZONE_TEMPLATE_ID",
-                distTemplate: "DISTRICT_TEMPLATE_ID",
-                areaTemplate: "AREA_TEMPLATE_ID",
-            }
+{
+    docIds_kicFormId: "KIC_FORM_ID",
+    reportCreator: {
+        docIDs: {
+            zoneTemplate: "ZONE_TEMPLATE_ID",
+            distTemplate: "DISTRICT_TEMPLATE_ID",
+            areaTemplate: "AREA_TEMPLATE_ID",
         }
     }
+}
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,15 @@
 # Deploy Google App Script Action with TypeScript Compilation
 
-[![Deploy Script](https://github.com/texas-mcallen-mission/deploy-google-app-script-action-typescript/actions/workflows/deploy-script.yml/badge.svg)](https://github.com/texas-mcallen-mission/deploy-google-app-script-action-typescript/actions/workflows/deploy-script.yml)
+[![Deploy Script](https://GitHub.com/texas-mcallen-mission/deploy-google-app-script-action-typescript/actions/workflows/deploy-script.yml/badge.svg)](https://GitHub.com/texas-mcallen-mission/deploy-google-app-script-action-typescript/actions/workflows/deploy-script.yml)
 
-This repository is an example of how to setup an automatic [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process for [Google Apps Script](https://developers.google.com/apps-script) using [GitHub Actions](https://docs.github.com/en/actions).
+This repository is an example of how to setup an automatic [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process for [Google Apps Script](https://developers.google.com/apps-script) using [GitHub Actions](https://docs.GitHub.com/en/actions).
 
-*forked from [https://github.com/ericanastas/deploy-google-app-script-action](ericanastas/deploy-google-app-script-action)*
+*forked from [https://GitHub.com/ericanastas/deploy-google-app-script-action](ericanastas/deploy-google-app-script-action)*
  - major changes:
-   - saves extra [GitHub action context data](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) data in a object stored in ``git-info.js``
+   - saves extra [GitHub action context data](https://docs.GitHub.com/en/actions/learn-GitHub-actions/contexts#GitHub-context) data in a object stored in ``git-info.js``
    - adds the ability to have a document container by setting ``PARENT_ID`` in actions secrets.
    - ``commitTracker.js`` will automatically log whenever the script in GAS gets updated if you set up a recurring trigger for it.
-    - at present, this requires a parent container.
+   - at present, this requires a parent container.
 
 [Demo Google Sheet, Vanilla](https://docs.google.com/spreadsheets/d/1tli_An8Jg5-UQltOtRla7pz-mPRAYDfhExRkkVA2oJE/edit?usp=sharing)
 [Demo Google Sheet, Typescript](https://docs.google.com/spreadsheets/d/1jEbB5RxGvxuUd00X7UAuTqKZjBRqYsIt88dhF3tRHh8/edit?usp=sharing)
@@ -20,7 +20,7 @@ In your editor of choice, run [``npm install --save @types/google-apps-script``]
 
 ## Why?
 
-This is useful if you want to work from a nicer editor than the built-in Google one (ie vsCode) and use GitHub for version control & etc.  There's probably a better thing to use for standalone GAS scripts or stuff that uses features of GCP, but if you don't have access to GCP because your organization locked down your gSuite access a little too much, this is a nice alternative.
+This is useful if you want to work from a nicer editor than the built-in Google one (I.E. vsCode) and use GitHub for version control & etc.  There's probably a better thing to use for standalone GAS scripts or stuff that uses features of GCP, but if you don't have access to GCP because your organization locked down your gSuite access a little too much, this is a nice alternative.
 
 ## Setup
 
@@ -30,8 +30,8 @@ This is useful if you want to work from a nicer editor than the built-in Google 
 2. Create a local copy of a Google Apps Script project. You may use `clasp create` to create a new project or `clasp clone` to download an existing project. This will create a `.clasp.json` file.
 3. Initialize the project folder as a new Git repo: `git init`. 
    1. The `.clasp.json` file created in the prior step MUST be in the root of the Git repository, 
-   2. `.clasp.json` may point to source files in a sub folder throgh a `rootDir` property. 
-4. Copy `.github/workflows/deploy-script.yml` from this repository to the same relative path.
+   2. `.clasp.json` may point to source files in a sub folder through a `rootDir` property. 
+4. Copy `.GitHub/workflows/deploy-script.yml` from this repository to the same relative path.
 
 
 #### `.clasp.json` File Format Reference
@@ -52,7 +52,7 @@ This is useful if you want to work from a nicer editor than the built-in Google 
 2. Commit files: `git commit -m "first commit"`
 3. Create a `develop` branch: `git branch -M develop`
 4. Create a `main` branch: `git branch -M main`
-5.  Create a new GitHub repository, and add it as a remote: `git remote add origin git@github.com:account/repo.git`
+5.  Create a new GitHub repository, and add it as a remote: `git remote add origin git@GitHub.com:account/repo.git`
 6.  Push the `main` branch to GitHub: `git push -u origin main`
 7. Push the `develop` branch to GitHub: `git push -u origin develop`
 
@@ -60,7 +60,7 @@ At this point the workflow will be triggered, but will fail because it is not co
 
 ### Set Repository Secrets
 
-[Github encrypted secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) are used to configure the workflow and can be set from the repository settings page on GitHub.
+[GitHub encrypted secrets](https://docs.GitHub.com/en/actions/reference/encrypted-secrets) are used to configure the workflow and can be set from the repository settings page on GitHub.
 #### `CLASPRC_JSON`
 
 The `clasp` command line tool uses a `.clasprc.json` file to store the current login information. The contents of this file need to be added to a `CLASPRC_JSON` secret to allow the workflow to update and deploy scripts.
@@ -72,9 +72,9 @@ The `clasp` command line tool uses a `.clasprc.json` file to store the current l
 3. Copy the contents of `.clasprc.json` into a new secret named `CLASPRC_JSON`
 
 #### `REPO_ACCESS_TOKEN`
-A GitHub personal access token must be provided to the workfow to allow it to update the `CLASPRC_JSON` secret configured about when tokens expire and refresh.
+A GitHub personal access token must be provided to the workflow to allow it to update the `CLASPRC_JSON` secret configured about when tokens expire and refresh.
 
-1. Create a new [GitHubpersonal access token](https://github.com/settings/tokens/new) with `repo` scope.
+1. Create a new [GitHub personal access token](https://GitHub.com/settings/tokens/new) with `repo` scope.
 2. Copy the token into a new secret named `REPO_ACCESS_TOKEN`
 
 #### `SCRIPT_ID` [OPTIONAL]
@@ -87,15 +87,36 @@ This is for projects that have a container document, such as a spreadsheet. Simi
 
 #### `DEPLOYMENT_ID` [OPTIONAL]
 
-The workflow can automatically deploy the script when the `main` branch is pushed to github.
+The workflow can automatically deploy the script when the `main` branch is pushed to GitHub.
 
 1. Determine the ID of the deployment you want
-   1. Create a new deployment by running `clasp deploy` or on https://scripts.google.com.
-   2. Find the deploymen id by running `clasp deployments` or checking the projet settings on https://scripts.google.com.
-2. Add the desired deployment id to a secret naned `DEPLOYMENT_ID`
+   1. Create a new deployment by running `clasp deploy` or on [https://scripts.google.com](https://scripts.google.com).
+   2. Find the deployment id by running `clasp deployments` or checking the project settings on <https://scripts.google.com>.
+2. Add the desired deployment id to a secret named `DEPLOYMENT_ID`
+
+
+#### `CONFIG_JSON` [OPTIONAL]
+
+(New!)  This allows you to stick extra config data that you want to supersede the stuff in the default configuration inside of an action secret.  It'd probably be a good idea to save the contents of this somewhere outside of your repository so that you can reference it later in case you need to make changes.  This will also make maintaining multiple deployments easier, as all deployment-specific configuration bits can be stuck in here.
+
+##### Example snippet
+
+```js
+    {
+        docIds_kicFormId: "KIC_FORM_ID",
+        reportCreator: {
+            docIDs: {
+                zoneTemplate: "ZONE_TEMPLATE_ID",
+                distTemplate: "DISTRICT_TEMPLATE_ID",
+                areaTemplate: "AREA_TEMPLATE_ID",
+            }
+        }
+    }
+```
+
 ## Usage
 
-- Pushing to either the `main` or `develop` branches on github will automatically trigger the workflow to push the code to the `HEAD` deployment on https://scripts.google.com`
+- Pushing to either the `main` or `develop` branches on GitHub will automatically trigger the workflow to push the code to the `HEAD` deployment on [https://scripts.google.com](https://scripts.google.com)`
 - If the `DEPLOYMENT_ID` secret has been setup pushing to `main` will also deploy the script to the specified deployment.
 
 ## Updating `.clasprc.json`
@@ -125,33 +146,11 @@ The "correct" way to setup a server to server connection like is through a GCP s
   
 ## Related Issues
 
-- [Provide instructions for deploying via CI #707](https://github.com/google/clasp/issues/707)
-- [Handle rc files prefering local over global to make clasp more CI friendly #486](https://github.com/google/clasp/pull/486)
-- [Integration with CI pipeline and Jenkins #524](https://github.com/google/clasp/issues/524)
-- [How to use a service account for CI deployments #225](https://github.com/google/clasp/issues/225)
+- [Provide instructions for deploying via CI #707](https://GitHub.com/google/clasp/issues/707)
+- [Handle rc files preferring local over global to make clasp more CI friendly #486](https://GitHub.com/google/clasp/pull/486)
+- [Integration with CI pipeline and Jenkins #524](https://GitHub.com/google/clasp/issues/524)
+- [How to use a service account for CI deployments #225](https://GitHub.com/google/clasp/issues/225)
 
 ## Reference
 
-- [Advanced Clasp Docs](https://github.com/google/clasp/tree/master/docs)
-  
-
-
-
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+- [Advanced Clasp Docs](https://GitHub.com/google/clasp/tree/master/docs)


### PR DESCRIPTION
This update is more specifically for the key indicator system.  Why it's important- this will let you stick sensitive bits of config data into GitHub's action secrets instead of having it publicly available.  This is useful for two reasons:
1.  It's now easier to maintain development versions, and have multiple configurations pre-set and ready to go
  * All that you need to do to create multiple environments is basically duplicate the workflow, add some more secrets with similar data (IE a secret named ``TEST_INSTANCE_2_SCRIPT_ID``)  and change the references to the workflow branches to use the new thing.
 2. It's a lot more secure!  You won't have to leak document ID's out to the world with your published-everywhere version, meaning that your live release stuff *could* live in a public repository.